### PR TITLE
Allow providing display labels for cell values

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ ExpandableDataTable is a Flutter library for dealing with displaying and editing
 | renderEditDialog       | Render function that builds a custom edit dialog widget                  |
 | renderCustomPagination | Render function that builds a custom pagination widget                   |
 | renderExpansionContent | Render function that builds custom expansion container for all rows      |
+| createCellValueDisplayLabel | Allows change how a value is displayed (e.g. formatting)            |
+
 
 <br />
 

--- a/lib/src/expandable_datatable.dart
+++ b/lib/src/expandable_datatable.dart
@@ -156,6 +156,11 @@ class ExpandableDataTable extends StatefulWidget {
     ExpandableRow row,
   )? renderExpansionContent;
 
+  /// Display label provider for cell values that allows changing how a value
+  /// is displayed but not how it behaves for e.g. sorting
+  final String Function(String columTitle, Object value)?
+      createCellValueDisplayLabel;
+
   ExpandableDataTable({
     Key? key,
     required this.headers,
@@ -169,6 +174,7 @@ class ExpandableDataTable extends StatefulWidget {
     this.renderEditDialog,
     this.renderCustomPagination,
     this.renderExpansionContent,
+    this.createCellValueDisplayLabel,
   })  : assert(visibleColumnCount > 0),
         assert(
           rows.isNotEmpty ? headers.length == rows.first.cells.length : true,
@@ -248,7 +254,10 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
         titleCells.add(
           CellItem(
             columnName: element.columnTitle,
-            value: element.value,
+            value: widget.createCellValueDisplayLabel == null
+                ? element.value
+                : widget.createCellValueDisplayLabel!(
+                    element.columnTitle, element.value),
             flex: _headerTitles[headerInd].columnFlex,
           ),
         );
@@ -256,7 +265,10 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
         expansionCells.add(
           CellItem(
             columnName: element.columnTitle,
-            value: element.value,
+            value: widget.createCellValueDisplayLabel == null
+                ? element.value
+                : widget.createCellValueDisplayLabel!(
+                    element.columnTitle, element.value),
           ),
         );
       }


### PR DESCRIPTION
For data tables it can be quite important to display data in a certain way like formatting numbers and dates.
To simply provide the formatted value for the cell is often not enough because it would mess up the sorting e.g. dates in en_US locale will not sort properly as string values

This is a small and backwards compatible change to address this issue