### PR TITLE
Update table content when data changes via  provider

### DIFF
--- a/lib/src/expandable_datatable.dart
+++ b/lib/src/expandable_datatable.dart
@@ -320,7 +320,7 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
     _composeRowsList(widget.rows, isInit: true);
 
     // adjust current page if resize caused the page to not exist
-    if(_currentPage > _sortedRowsList.length){
+    if (_sortedRowsList.isNotEmpty && _currentPage >= _sortedRowsList.length) {
       _currentPage = _sortedRowsList.length - 1;
     }
 

--- a/lib/src/expandable_datatable.dart
+++ b/lib/src/expandable_datatable.dart
@@ -196,14 +196,14 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
   int _currentPage = 0;
   int _selectedRow = -1;
 
+  ExpandableColumn? _sortColumn;
+
   int get pageLength =>
       _sortedRowsList.isNotEmpty ? _sortedRowsList[_currentPage].length : 0;
 
   @override
   void initState() {
     super.initState();
-
-    _composeRowsList(widget.rows, isInit: true);
   }
 
   @override
@@ -322,6 +322,12 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
 
   @override
   Widget build(BuildContext context) {
+    _composeRowsList(widget.rows, isInit: true);
+
+    if (_sortOperations.sortInformation.sortedColumn != null) {
+      _sortRows(_sortOperations.sortInformation.sortedColumn!);
+    }
+
     return Column(
       children: [
         buildHeader(),
@@ -436,7 +442,11 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
     return TableHeader(
       headerRow: _headerTitles,
       currentSort: _sortOperations.sortInformation,
-      onTitleTap: _sortRows,
+      onTitleTap: (column) {
+        setState(() {
+          _sortOperations.changeSortDirection(column);
+        });
+      },
       trailingWidth: _trailingWidth,
     );
   }

--- a/lib/src/expandable_datatable.dart
+++ b/lib/src/expandable_datatable.dart
@@ -319,6 +319,11 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
   Widget build(BuildContext context) {
     _composeRowsList(widget.rows, isInit: true);
 
+    // adjust current page if resize caused the page to not exist
+    if(_currentPage > _sortedRowsList.length){
+      _currentPage = _sortedRowsList.length - 1;
+    }
+
     if (_sortOperations.sortInformation.sortedColumn != null) {
       _sortRows(_sortOperations.sortInformation.sortedColumn!);
     }

--- a/lib/src/expandable_datatable.dart
+++ b/lib/src/expandable_datatable.dart
@@ -196,8 +196,6 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
   int _currentPage = 0;
   int _selectedRow = -1;
 
-  ExpandableColumn? _sortColumn;
-
   int get pageLength =>
       _sortedRowsList.isNotEmpty ? _sortedRowsList[_currentPage].length : 0;
 
@@ -265,9 +263,6 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
 
   /// Sort all rows.
   void _sortRows(ExpandableColumn column) {
-    ///Resets the page and go back to first page.
-    _currentPage = 0;
-
     List<SortableRow> tempSortArray =
         _sortOperations.sortAllRows(column, _sortedRowsList);
 
@@ -445,6 +440,9 @@ class _ExpandableDataTableState extends State<ExpandableDataTable> {
       onTitleTap: (column) {
         setState(() {
           _sortOperations.changeSortDirection(column);
+
+          ///Resets the page and go back to first page.
+          _currentPage = 0;
         });
       },
       trailingWidth: _trailingWidth,

--- a/lib/src/utility/sort_operations.dart
+++ b/lib/src/utility/sort_operations.dart
@@ -10,12 +10,14 @@ class SortOperations {
     sortInformation = SortInformation();
   }
 
+  void changeSortDirection(ExpandableColumn column) {
+    sortInformation.nextSort(column);
+  }
+
   List<SortableRow> sortAllRows(
     ExpandableColumn column,
     List<List<SortableRow>> twoDimensionList,
   ) {
-    sortInformation.nextSort(column);
-
     List<SortableRow> tempSortArray = createTempArray(twoDimensionList);
 
     if (sortInformation.sortOption == SortOption.NORMAL) {

--- a/lib/src/widget/pagination_widget.dart
+++ b/lib/src/widget/pagination_widget.dart
@@ -43,39 +43,6 @@ class _PaginationWidgetState extends State<PaginationWidget> {
     }
   }
 
-  @override
-  void initState() {
-    super.initState();
-
-    _totalPageCount = widget.totalPageCount;
-
-    if (_totalPageCount == 0) {
-      _toggleButtons = [];
-    } else if (_totalPageCount == 1) {
-      /// The total number of pages is 1, there is no need to have previous and
-      /// next buttons.
-      _toggleButtons = [true];
-    } else if (_totalPageCount <= widget.maxVisiblePage) {
-      /// Total page count is smaller than or equal to wanted shown page count. So,
-      /// all pages will have their own buttons and previous and next buttons will
-      /// be shown.
-      _toggleButtons = List.filled(_totalPageCount + 2, false);
-
-      /// First page is selected initially.
-      _toggleButtons[1] = true;
-    } else {
-      /// Total page count is greater than the wanted shown page count. So, it needs
-      /// to have a dynamic button appearances.
-      _toggleButtons = List.filled(widget.maxVisiblePage + 2, false);
-
-      /// Middle point is equal to integer division of the wanted shown page count.
-      _midPoint = midPointMargin;
-
-      /// First page is selected initially.
-      _toggleButtons[1] = true;
-    }
-  }
-
   int get midPointMargin => widget.maxVisiblePage ~/ 2;
 
   /// Gives the previous button's index in the [_toggleButtons] list.
@@ -150,6 +117,33 @@ class _PaginationWidgetState extends State<PaginationWidget> {
   Widget build(BuildContext context) {
     final ExpandableThemeData theme = context.expandableTheme;
     final double size = theme.paginationSize;
+
+    _totalPageCount = widget.totalPageCount;
+
+    if (_totalPageCount == 0) {
+      _toggleButtons = [];
+    } else if (_totalPageCount == 1) {
+      /// The total number of pages is 1, there is no need to have previous and
+      /// next buttons.
+      _toggleButtons = [true];
+    } else if (_totalPageCount <= widget.maxVisiblePage) {
+      /// Total page count is smaller than or equal to wanted shown page count. So,
+      /// all pages will have their own buttons and previous and next buttons will
+      /// be shown.
+      _toggleButtons = List.filled(_totalPageCount + 2, false);
+    } else {
+      /// Total page count is greater than the wanted shown page count. So, it needs
+      /// to have a dynamic button appearances.
+      _toggleButtons = List.filled(widget.maxVisiblePage + 2, false);
+
+      /// Middle point is equal to integer division of the wanted shown page count.
+      _midPoint = midPointMargin;
+    }
+
+    if (_toggleButtons.length > 1) {
+      _changeMidPoint(widget.currentPage);
+      _setButtons(widget.currentPage);
+    }
 
     return ToggleButtons(
       constraints: BoxConstraints(minHeight: size, minWidth: size),

--- a/lib/src/widget/pagination_widget.dart
+++ b/lib/src/widget/pagination_widget.dart
@@ -30,19 +30,6 @@ class _PaginationWidgetState extends State<PaginationWidget> {
 
   late int _totalPageCount;
 
-  @override
-  void didUpdateWidget(covariant PaginationWidget oldWidget) {
-    super.didUpdateWidget(oldWidget);
-
-    if (widget.currentPage != oldWidget.currentPage) {
-      setState(() {
-        _changeMidPoint(widget.currentPage);
-
-        _setButtons(widget.currentPage);
-      });
-    }
-  }
-
   int get midPointMargin => widget.maxVisiblePage ~/ 2;
 
   /// Gives the previous button's index in the [_toggleButtons] list.

--- a/lib/src/widget/pagination_widget.dart
+++ b/lib/src/widget/pagination_widget.dart
@@ -106,6 +106,7 @@ class _PaginationWidgetState extends State<PaginationWidget> {
     final double size = theme.paginationSize;
 
     _totalPageCount = widget.totalPageCount;
+    _midPoint = null;
 
     if (_totalPageCount == 0) {
       _toggleButtons = [];

--- a/lib/src/widget/table_header.dart
+++ b/lib/src/widget/table_header.dart
@@ -94,7 +94,7 @@ class TableHeader extends StatelessWidget {
               ),
               Visibility(
                 visible: currentSort.sortedColumn != null &&
-                    currentSort.sortedColumn == column,
+                    currentSort.sortedColumn!.columnTitle == column.columnTitle,
                 child: currentSort.sortOption == SortOption.ASC
                     ? Icon(
                         Icons.arrow_drop_up,


### PR DESCRIPTION
fixes ismailyegnr/expandable_datatable#4

The problem was that the table content was created in the initState method instead of build method. Init state is only called once when constructing the widget while build is repeadedly called when things change in the UI allowing the view to update. I also had to ajust the sorting mechanism a little so the sort state does not get lost during rebuilds