### PR TITLE
Fix the Icon overflow on editable option

### DIFF
--- a/lib/src/constants/constants.dart
+++ b/lib/src/constants/constants.dart
@@ -5,6 +5,6 @@ class GeneralConstants {
 
   static const double titlePadding = 8;
 
-  static const double largeTrailing = 0.15;
+  static const double largeTrailing = 0.16;
   static const double smallTrailing = 0.08;
 }


### PR DESCRIPTION
**Fix the large trailing value for icons display overflow on edit option.**
Whenever the editable option is set to "**true**", the two icons in the Row widget takes up more space than the GeneralConstants.largeTrailing value.

Before:
<img width="300" alt="Screenshot 2024-12-05 at 8 15 59 PM" src="https://github.com/user-attachments/assets/e1e12458-074c-4112-a72a-6fcce01b8e9b">

After:
<img width="300" alt="Screenshot 2024-12-05 at 8 30 42 PM" src="https://github.com/user-attachments/assets/8f5df1da-24bc-4ca0-a813-a13bbc8d83fd">
